### PR TITLE
Morgana 3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM node:16 AS base
+FROM node:17 AS base
 
 USER node
 WORKDIR /apps/node/morgana/src
-VOLUME [ "/apps/node/morgana/src" ]
 RUN chown -R node:node /apps/node/morgana/src
 
 FROM base AS builder

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       target: production
     container_name: morgana
-    image: asubowo/morgana:2.2
+    image: asubowo/morgana:3.0
     restart: unless-stopped
     env_file: .env
     network_mode: bridge

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "morgana",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {}
 }

--- a/src/commands/utils/openai.js
+++ b/src/commands/utils/openai.js
@@ -26,7 +26,7 @@ var chatgpt = function(messageContext, openai, client) {
       let conversationHistory = [context];
       let maxLength = 2000; // The current max character length of a Discord message
 
-      let prevMessages = await messageContext.channel.messages.fetch({ limit: 15 });
+      let prevMessages = await messageContext.channel.messages.fetch({ limit: 30 });
       prevMessages.reverse();
       prevMessages.forEach((msg) => {
         // Thanks Under Ctrl for the regex.

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,25 +1,26 @@
 {
   "name": "morgana",
-  "version": "1.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "morgana",
-      "version": "1.0.0",
+      "version": "3.0.0",
       "license": "ISC",
       "dependencies": {
-        "@discordjs/opus": "^0.8.0",
-        "@discordjs/rest": "^1.0.1",
-        "@discordjs/voice": "^0.11.0",
-        "discord.js": "^14.2.0",
-        "dotenv": "^16.0.1",
-        "ffmpeg-static": "^5.0.2",
-        "libsodium-wrappers": "^0.7.10",
-        "openai": "^4.0.0",
-        "opusscript": "^0.0.8",
+        "@discordjs/opus": "^0.9.0",
+        "@discordjs/rest": "^2.2.0",
+        "@discordjs/voice": "^0.16.1",
+        "@mapbox/node-pre-gyp": "^1.0.11",
+        "discord.js": "^14.14.1",
+        "dotenv": "^16.3.1",
+        "ffmpeg-static": "^5.2.0",
+        "libsodium-wrappers": "^0.7.13",
+        "openai": "^4.20.1",
+        "opusscript": "^0.1.1",
         "speedtest-net": "^2.2.0",
-        "yahoo-finance2": "^2.4.1"
+        "yahoo-finance2": "^2.9.0"
       }
     },
     "node_modules/@derhuerst/http-basic": {
@@ -37,58 +38,40 @@
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.6.5.tgz",
-      "integrity": "sha512-SdweyCs/+mHj+PNhGLLle7RrRFX9ZAhzynHahMCLqp5Zeq7np7XC6/mgzHc79QoVlQ1zZtOkTTiJpOZu5V8Ufg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.7.0.tgz",
+      "integrity": "sha512-GDtbKMkg433cOZur8Dv6c25EHxduNIBsxeHrsRoIM8+AwmEZ8r0tEpckx/sHwTLwQPOF3e2JWloZh9ofCaMfAw==",
       "dependencies": {
-        "@discordjs/formatters": "^0.3.2",
-        "@discordjs/util": "^1.0.1",
-        "@sapphire/shapeshift": "^3.9.2",
-        "discord-api-types": "0.37.50",
+        "@discordjs/formatters": "^0.3.3",
+        "@discordjs/util": "^1.0.2",
+        "@sapphire/shapeshift": "^3.9.3",
+        "discord-api-types": "0.37.61",
         "fast-deep-equal": "^3.1.3",
         "ts-mixer": "^6.0.3",
-        "tslib": "^2.6.1"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.11.0"
       }
     },
-    "node_modules/@discordjs/builders/node_modules/@discordjs/util": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.0.1.tgz",
-      "integrity": "sha512-d0N2yCxB8r4bn00/hvFZwM7goDcUhtViC5un4hPj73Ba4yrChLSJD8fy7Ps5jpTLg1fE9n4K0xBLc1y9WGwSsA==",
-      "engines": {
-        "node": ">=16.11.0"
-      }
-    },
-    "node_modules/@discordjs/builders/node_modules/discord-api-types": {
-      "version": "0.37.50",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.50.tgz",
-      "integrity": "sha512-X4CDiMnDbA3s3RaUXWXmgAIbY1uxab3fqe3qwzg5XutR3wjqi7M3IkgQbsIBzpqBN2YWr/Qdv7JrFRqSgb4TFg=="
-    },
     "node_modules/@discordjs/collection": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
-      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.0.0.tgz",
+      "integrity": "sha512-YTWIXLrf5FsrLMycpMM9Q6vnZoR/lN2AWX23/Cuo8uOOtS8eHB2dyQaaGnaF8aZPYnttf2bkLMcXn/j6JUOi3w==",
       "engines": {
-        "node": ">=16.11.0"
+        "node": ">=18"
       }
     },
     "node_modules/@discordjs/formatters": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.2.tgz",
-      "integrity": "sha512-lE++JZK8LSSDRM5nLjhuvWhGuKiXqu+JZ/DsOR89DVVia3z9fdCJVcHF2W/1Zxgq0re7kCzmAJlCMMX3tetKpA==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.3.tgz",
+      "integrity": "sha512-wTcI1Q5cps1eSGhl6+6AzzZkBBlVrBdc9IUhJbijRgVjCNIIIZPgqnUj3ntFODsHrdbGU8BEG9XmDQmgEEYn3w==",
       "dependencies": {
-        "discord-api-types": "0.37.50"
+        "discord-api-types": "0.37.61"
       },
       "engines": {
         "node": ">=16.11.0"
       }
-    },
-    "node_modules/@discordjs/formatters/node_modules/discord-api-types": {
-      "version": "0.37.50",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.50.tgz",
-      "integrity": "sha512-X4CDiMnDbA3s3RaUXWXmgAIbY1uxab3fqe3qwzg5XutR3wjqi7M3IkgQbsIBzpqBN2YWr/Qdv7JrFRqSgb4TFg=="
     },
     "node_modules/@discordjs/node-pre-gyp": {
       "version": "0.4.5",
@@ -110,12 +93,12 @@
       }
     },
     "node_modules/@discordjs/opus": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/opus/-/opus-0.8.0.tgz",
-      "integrity": "sha512-uHE7OmHEmP8YM0yvsH3iSdacdeghO0qTkF0CIkV07Tg0qdyOLUVkoZHj5Zcpge9rC4qb/JvTS2xRgttSZLM43Q==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/opus/-/opus-0.9.0.tgz",
+      "integrity": "sha512-NEE76A96FtQ5YuoAVlOlB3ryMPrkXbUCTQICHGKb8ShtjXyubGicjRMouHtP1RpuDdm16cDa+oI3aAMo1zQRUQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "@discordjs/node-pre-gyp": "^0.4.4",
+        "@discordjs/node-pre-gyp": "^0.4.5",
         "node-addon-api": "^5.0.0"
       },
       "engines": {
@@ -123,134 +106,138 @@
       }
     },
     "node_modules/@discordjs/rest": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.7.1.tgz",
-      "integrity": "sha512-Ofa9UqT0U45G/eX86cURQnX7gzOJLG2oC28VhIk/G6IliYgQF7jFByBJEykPSHE4MxPhqCleYvmsrtfKh1nYmQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.2.0.tgz",
+      "integrity": "sha512-nXm9wT8oqrYFRMEqTXQx9DUTeEtXUDMmnUKIhZn6O2EeDY9VCdwj23XCPq7fkqMPKdF7ldAfeVKyxxFdbZl59A==",
       "dependencies": {
-        "@discordjs/collection": "^1.5.1",
-        "@discordjs/util": "^0.3.0",
-        "@sapphire/async-queue": "^1.5.0",
-        "@sapphire/snowflake": "^3.4.2",
-        "discord-api-types": "^0.37.41",
-        "file-type": "^18.3.0",
-        "tslib": "^2.5.0",
-        "undici": "^5.22.0"
-      },
-      "engines": {
-        "node": ">=16.9.0"
-      }
-    },
-    "node_modules/@discordjs/util": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.3.1.tgz",
-      "integrity": "sha512-HxXKYKg7vohx2/OupUN/4Sd02Ev3PBJ5q0gtjdcvXb0ErCva8jNHWfe/v5sU3UKjIB/uxOhc+TDOnhqffj9pRA==",
-      "engines": {
-        "node": ">=16.9.0"
-      }
-    },
-    "node_modules/@discordjs/voice": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/voice/-/voice-0.11.0.tgz",
-      "integrity": "sha512-6+9cj1dxzBJm7WJ9qyG2XZZQ8rcLl6x2caW0C0OxuTtMLAaEDntpb6lqMTFiBg/rDc4Rd59g1w0gJmib33CuHw==",
-      "dependencies": {
-        "@types/ws": "^8.5.3",
-        "discord-api-types": "^0.36.2",
-        "prism-media": "^1.3.4",
-        "tslib": "^2.4.0",
-        "ws": "^8.8.1"
-      },
-      "engines": {
-        "node": ">=16.9.0"
-      }
-    },
-    "node_modules/@discordjs/voice/node_modules/discord-api-types": {
-      "version": "0.36.3",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
-      "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg=="
-    },
-    "node_modules/@discordjs/ws": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.0.1.tgz",
-      "integrity": "sha512-avvAolBqN3yrSvdBPcJ/0j2g42ABzrv3PEL76e3YTp2WYMGH7cuspkjfSyNWaqYl1J+669dlLp+YFMxSVQyS5g==",
-      "dependencies": {
-        "@discordjs/collection": "^1.5.3",
-        "@discordjs/rest": "^2.0.1",
-        "@discordjs/util": "^1.0.1",
-        "@sapphire/async-queue": "^1.5.0",
-        "@types/ws": "^8.5.5",
-        "@vladfrangu/async_event_emitter": "^2.2.2",
-        "discord-api-types": "0.37.50",
-        "tslib": "^2.6.1",
-        "ws": "^8.13.0"
-      },
-      "engines": {
-        "node": ">=16.11.0"
-      }
-    },
-    "node_modules/@discordjs/ws/node_modules/@discordjs/rest": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.0.1.tgz",
-      "integrity": "sha512-/eWAdDRvwX/rIE2tuQUmKaxmWeHmGealttIzGzlYfI4+a7y9b6ZoMp8BG/jaohs8D8iEnCNYaZiOFLVFLQb8Zg==",
-      "dependencies": {
-        "@discordjs/collection": "^1.5.3",
-        "@discordjs/util": "^1.0.1",
+        "@discordjs/collection": "^2.0.0",
+        "@discordjs/util": "^1.0.2",
         "@sapphire/async-queue": "^1.5.0",
         "@sapphire/snowflake": "^3.5.1",
         "@vladfrangu/async_event_emitter": "^2.2.2",
-        "discord-api-types": "0.37.50",
-        "magic-bytes.js": "^1.0.15",
-        "tslib": "^2.6.1",
-        "undici": "5.22.1"
+        "discord-api-types": "0.37.61",
+        "magic-bytes.js": "^1.5.0",
+        "tslib": "^2.6.2",
+        "undici": "5.27.2"
       },
       "engines": {
         "node": ">=16.11.0"
       }
     },
-    "node_modules/@discordjs/ws/node_modules/@discordjs/util": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.0.1.tgz",
-      "integrity": "sha512-d0N2yCxB8r4bn00/hvFZwM7goDcUhtViC5un4hPj73Ba4yrChLSJD8fy7Ps5jpTLg1fE9n4K0xBLc1y9WGwSsA==",
+    "node_modules/@discordjs/util": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.0.2.tgz",
+      "integrity": "sha512-IRNbimrmfb75GMNEjyznqM1tkI7HrZOf14njX7tCAAUetyZM1Pr8hX/EK2lxBCOgWDRmigbp24fD1hdMfQK5lw==",
       "engines": {
         "node": ">=16.11.0"
       }
     },
-    "node_modules/@discordjs/ws/node_modules/discord-api-types": {
-      "version": "0.37.50",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.50.tgz",
-      "integrity": "sha512-X4CDiMnDbA3s3RaUXWXmgAIbY1uxab3fqe3qwzg5XutR3wjqi7M3IkgQbsIBzpqBN2YWr/Qdv7JrFRqSgb4TFg=="
-    },
-    "node_modules/@discordjs/ws/node_modules/undici": {
-      "version": "5.22.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
-      "integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
+    "node_modules/@discordjs/voice": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/voice/-/voice-0.16.1.tgz",
+      "integrity": "sha512-uiWiW0Ta6K473yf8zs13RfKuPqm/xU4m4dAidMkIdwqgy1CztbbZBtPLfDkVSKzpW7s6m072C+uQcs4LwF3FhA==",
       "dependencies": {
-        "busboy": "^1.6.0"
+        "@types/ws": "^8.5.9",
+        "discord-api-types": "0.37.61",
+        "prism-media": "^1.3.5",
+        "tslib": "^2.6.2",
+        "ws": "^8.14.2"
       },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/voice/node_modules/opusscript": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
+      "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@discordjs/voice/node_modules/prism-media": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.5.tgz",
+      "integrity": "sha512-IQdl0Q01m4LrkN1EGIE9lphov5Hy7WWlH6ulf5QdGePLlPas9p2mhgddTEHrlaXYjjFToM1/rWuwF37VF4taaA==",
+      "peerDependencies": {
+        "@discordjs/opus": ">=0.8.0 <1.0.0",
+        "ffmpeg-static": "^5.0.2 || ^4.2.7 || ^3.0.0 || ^2.4.0",
+        "node-opus": "^0.3.3",
+        "opusscript": "^0.0.8"
+      },
+      "peerDependenciesMeta": {
+        "@discordjs/opus": {
+          "optional": true
+        },
+        "ffmpeg-static": {
+          "optional": true
+        },
+        "node-opus": {
+          "optional": true
+        },
+        "opusscript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@discordjs/ws": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.0.2.tgz",
+      "integrity": "sha512-+XI82Rm2hKnFwAySXEep4A7Kfoowt6weO6381jgW+wVdTpMS/56qCvoXyFRY0slcv7c/U8My2PwIB2/wEaAh7Q==",
+      "dependencies": {
+        "@discordjs/collection": "^2.0.0",
+        "@discordjs/rest": "^2.1.0",
+        "@discordjs/util": "^1.0.2",
+        "@sapphire/async-queue": "^1.5.0",
+        "@types/ws": "^8.5.9",
+        "@vladfrangu/async_event_emitter": "^2.2.2",
+        "discord-api-types": "0.37.61",
+        "tslib": "^2.6.2",
+        "ws": "^8.14.2"
+      },
+      "engines": {
+        "node": ">=16.11.0"
       }
     },
     "node_modules/@fastify/busboy": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
-      "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
+      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
       "engines": {
         "node": ">=14"
       }
     },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
     "node_modules/@sapphire/async-queue": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz",
-      "integrity": "sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.1.tgz",
+      "integrity": "sha512-1RdpsmDQR/aWfp8oJzPtn4dNQrbpqSL5PIA0uAB/XwerPXUf994Ug1au1e7uGcD7ei8/F63UDjr5GWps1g/HxQ==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/@sapphire/shapeshift": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.3.tgz",
-      "integrity": "sha512-WzKJSwDYloSkHoBbE8rkRW8UNKJiSRJ/P8NqJ5iVq7U2Yr/kriIBx2hW+wj2Z5e5EnXL1hgYomgaFsdK6b+zqQ==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.4.tgz",
+      "integrity": "sha512-SiOoCBmm8O7QuadLJnX4V0tAkhC54NIOZJtmvw+5zwnHaiulGkjY02wxCuK8Gf4V540ILmGz+UulC0U8mrOZjg==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "lodash": "^4.17.21"
@@ -261,9 +248,9 @@
       }
     },
     "node_modules/@sapphire/snowflake": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.1.tgz",
-      "integrity": "sha512-BxcYGzgEsdlG0dKAyOm0ehLGm2CafIrfQTZGWgkfKYbj+pNNsorZ7EotuZukc2MT70E0UbppVbtpBrqpzVzjNA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.2.tgz",
+      "integrity": "sha512-FTm9RdyELF21PQN5dS/HLRs90XqWclHa+p0gkonc+BA2X2QKfFySHSjUbO65rmArd/ghR9Ahj2fMfedTZEqzOw==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
@@ -277,45 +264,40 @@
         "node": ">=4"
       }
     },
-    "node_modules/@tokenizer/token": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
-    },
     "node_modules/@types/node": {
-      "version": "20.8.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
-      "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
+      "version": "20.10.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.3.tgz",
+      "integrity": "sha512-XJavIpZqiXID5Yxnxv3RUDKTN5b81ddNC3ecsA0SoFXz/QU8OGBwZGMomiq0zw+uuqbL/krztv/DINAQ/EV4gg==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
     },
     "node_modules/@types/node-fetch": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.8.tgz",
-      "integrity": "sha512-nnH5lV9QCMPsbEVdTb5Y+F3GQxLSw1xQgIydrb2gSfEavRPs50FnMr+KUaa+LoPSqibm2N+ZZxH7lavZlAT4GA==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-bQVlnMLFJ2d35DkPNjEPmd9ueO/rh5EiaZt2bhqiSarPjZIuIV6bPQVqcrEyvNo+AfTrRGVazle1tl597w3gfA==",
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.0"
       }
     },
     "node_modules/@types/tough-cookie": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.4.tgz",
-      "integrity": "sha512-95Sfz4nvMAb0Nl9DTxN3j64adfwfbBPEYq14VN7zT5J5O2M9V6iZMIIQU1U+pJyl9agHYHNCqhCXgyEtIRRa5A=="
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="
     },
     "node_modules/@types/ws": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.8.tgz",
-      "integrity": "sha512-flUksGIQCnJd6sZ1l5dqCEG/ksaoAg/eUwiLAGTJQcfgvZJKF++Ta4bJA6A5aPSJmsr+xlseHn4KLgVlNnvPTg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
+      "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@vladfrangu/async_event_emitter": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.2.2.tgz",
-      "integrity": "sha512-HIzRG7sy88UZjBJamssEczH5q7t5+axva19UbZLO6u0ySbYPrwzWiXBcC0WuHyhKKoeCyneH+FvYzKQq/zTtkQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.2.4.tgz",
+      "integrity": "sha512-ButUPz9E9cXMLgvAW8aLAKKJJsPu1dY1/l/E8xzLFuysowXygs6GBcyunK9rnGC4zTsnIc2mQo71rGw9U+Ykug==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
@@ -579,17 +561,6 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
-      }
-    },
     "node_modules/cacheable-request": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
@@ -844,14 +815,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/decompress-tar/node_modules/file-type": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
-      "integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/decompress-tarbz2": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
@@ -884,14 +847,6 @@
         "file-type": "^5.2.0",
         "is-stream": "^1.1.0"
       },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress-targz/node_modules/file-type": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
-      "integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==",
       "engines": {
         "node": ">=4"
       }
@@ -1009,75 +964,57 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.37.62",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.62.tgz",
-      "integrity": "sha512-KpLQ6TiylGSSHj8AQW8Hz1ek1MkBbQUWs4gZhWH0rvSsWSj9tfav6EIitSxbFmqveqfu8oiPFI7vgFE4kBhTcQ=="
+      "version": "0.37.61",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.61.tgz",
+      "integrity": "sha512-o/dXNFfhBpYHpQFdT6FWzeO7pKc838QeeZ9d91CfVAtpr5XLK4B/zYxQbYgPdoMiTDvJfzcsLW5naXgmHGDNXw=="
     },
     "node_modules/discord.js": {
-      "version": "14.13.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.13.0.tgz",
-      "integrity": "sha512-Kufdvg7fpyTEwANGy9x7i4od4yu5c6gVddGi5CKm4Y5a6sF0VBODObI3o0Bh7TGCj0LfNT8Qp8z04wnLFzgnbA==",
+      "version": "14.14.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.14.1.tgz",
+      "integrity": "sha512-/hUVzkIerxKHyRKopJy5xejp4MYKDPTszAnpYxzVVv4qJYf+Tkt+jnT2N29PIPschicaEEpXwF2ARrTYHYwQ5w==",
       "dependencies": {
-        "@discordjs/builders": "^1.6.5",
-        "@discordjs/collection": "^1.5.3",
-        "@discordjs/formatters": "^0.3.2",
-        "@discordjs/rest": "^2.0.1",
-        "@discordjs/util": "^1.0.1",
-        "@discordjs/ws": "^1.0.1",
-        "@sapphire/snowflake": "^3.5.1",
-        "@types/ws": "^8.5.5",
-        "discord-api-types": "0.37.50",
-        "fast-deep-equal": "^3.1.3",
-        "lodash.snakecase": "^4.1.1",
-        "tslib": "^2.6.1",
-        "undici": "5.22.1",
-        "ws": "^8.13.0"
+        "@discordjs/builders": "^1.7.0",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.3.3",
+        "@discordjs/rest": "^2.1.0",
+        "@discordjs/util": "^1.0.2",
+        "@discordjs/ws": "^1.0.2",
+        "@sapphire/snowflake": "3.5.1",
+        "@types/ws": "8.5.9",
+        "discord-api-types": "0.37.61",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "tslib": "2.6.2",
+        "undici": "5.27.2",
+        "ws": "8.14.2"
       },
       "engines": {
         "node": ">=16.11.0"
       }
     },
-    "node_modules/discord.js/node_modules/@discordjs/rest": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.0.1.tgz",
-      "integrity": "sha512-/eWAdDRvwX/rIE2tuQUmKaxmWeHmGealttIzGzlYfI4+a7y9b6ZoMp8BG/jaohs8D8iEnCNYaZiOFLVFLQb8Zg==",
-      "dependencies": {
-        "@discordjs/collection": "^1.5.3",
-        "@discordjs/util": "^1.0.1",
-        "@sapphire/async-queue": "^1.5.0",
-        "@sapphire/snowflake": "^3.5.1",
-        "@vladfrangu/async_event_emitter": "^2.2.2",
-        "discord-api-types": "0.37.50",
-        "magic-bytes.js": "^1.0.15",
-        "tslib": "^2.6.1",
-        "undici": "5.22.1"
-      },
+    "node_modules/discord.js/node_modules/@discordjs/collection": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
       "engines": {
         "node": ">=16.11.0"
       }
     },
-    "node_modules/discord.js/node_modules/@discordjs/util": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.0.1.tgz",
-      "integrity": "sha512-d0N2yCxB8r4bn00/hvFZwM7goDcUhtViC5un4hPj73Ba4yrChLSJD8fy7Ps5jpTLg1fE9n4K0xBLc1y9WGwSsA==",
+    "node_modules/discord.js/node_modules/@sapphire/snowflake": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.1.tgz",
+      "integrity": "sha512-BxcYGzgEsdlG0dKAyOm0ehLGm2CafIrfQTZGWgkfKYbj+pNNsorZ7EotuZukc2MT70E0UbppVbtpBrqpzVzjNA==",
       "engines": {
-        "node": ">=16.11.0"
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
       }
     },
-    "node_modules/discord.js/node_modules/discord-api-types": {
-      "version": "0.37.50",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.50.tgz",
-      "integrity": "sha512-X4CDiMnDbA3s3RaUXWXmgAIbY1uxab3fqe3qwzg5XutR3wjqi7M3IkgQbsIBzpqBN2YWr/Qdv7JrFRqSgb4TFg=="
-    },
-    "node_modules/discord.js/node_modules/undici": {
-      "version": "5.22.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
-      "integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
+    "node_modules/discord.js/node_modules/@types/ws": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.9.tgz",
+      "integrity": "sha512-jbdrY0a8lxfdTp/+r7Z4CkycbOFN8WX+IOchLJr3juT/xzbJ8URyTVSJ/hvNdadTgM1mnedb47n+Y31GsFnQlg==",
       "dependencies": {
-        "busboy": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=14.0"
+        "@types/node": "*"
       }
     },
     "node_modules/dotenv": {
@@ -1247,19 +1184,11 @@
       }
     },
     "node_modules/file-type": {
-      "version": "18.6.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-18.6.0.tgz",
-      "integrity": "sha512-uLqXnIAIyy8K9rnvdU9IYi3WIL+6qVBWn24kThYOPlnyU+6yrr2oarn+j7seMLh1wOEG4hEjRP6a30IiKR9OaA==",
-      "dependencies": {
-        "readable-web-to-node-stream": "^3.0.2",
-        "strtok3": "^7.0.0",
-        "token-types": "^5.0.1"
-      },
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+      "integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==",
       "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+        "node": ">=4"
       }
     },
     "node_modules/filename-reserved-regex": {
@@ -1821,9 +1750,9 @@
       }
     },
     "node_modules/magic-bytes.js": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.5.0.tgz",
-      "integrity": "sha512-wJkXvutRbNWcc37tt5j1HyOK1nosspdh3dj6LUYYAvF6JYNqs53IfRvK9oEpcwiDA1NdoIi64yAMfdivPeVAyw=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.6.0.tgz",
+      "integrity": "sha512-eOGBE+NSCwU9dKKox93BPHjX4KSxIuiRY1/H1lkfxIagT0Llhs6bkRk8iqoP/0aeDl7FEZPa+ln5lay5mcNY4w=="
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
@@ -2368,9 +2297,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.14.2.tgz",
-      "integrity": "sha512-JGlm7mMC7J+cyQZnQMOH7daD9cBqqWqLtlBsejElEkgoehPrYfdyxSxIGICz5xk4YimbwI5FlLATSVojLtCKXQ==",
+      "version": "4.20.1",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.20.1.tgz",
+      "integrity": "sha512-Dd3q8EvINfganZFtg6V36HjrMaihqRgIcKiHua4Nq9aw/PxOP48dhbsk8x5klrxajt5Lpnc1KTOG5i1S6BKAJA==",
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -2387,17 +2316,17 @@
       }
     },
     "node_modules/openai/node_modules/@types/node": {
-      "version": "18.18.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.8.tgz",
-      "integrity": "sha512-OLGBaaK5V3VRBS1bAkMVP2/W9B+H8meUfl866OrMNQqt7wDgdpWPp5o6gmIc9pB+lIQHSq4ZL8ypeH1vPxcPaQ==",
+      "version": "18.19.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.2.tgz",
+      "integrity": "sha512-6wzfBdbWpe8QykUkXBjtmO3zITA0A3FIjoy+in0Y2K4KrCiRhNYJIdwAPDffZ3G6GnaKaSLSEa9ZuORLfEoiwg==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
     },
     "node_modules/opusscript": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
-      "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ=="
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.1.1.tgz",
+      "integrity": "sha512-mL0fZZOUnXdZ78woRXp18lApwpp0lF5tozJOD1Wut0dgrA9WuQTgSels/CSmFleaAZrJi/nci5KOVtbuxeWoQA=="
     },
     "node_modules/os-homedir": {
       "version": "1.0.2",
@@ -2483,18 +2412,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/peek-readable": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
-      "integrity": "sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A==",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -2533,31 +2450,6 @@
       "integrity": "sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/prism-media": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.5.tgz",
-      "integrity": "sha512-IQdl0Q01m4LrkN1EGIE9lphov5Hy7WWlH6ulf5QdGePLlPas9p2mhgddTEHrlaXYjjFToM1/rWuwF37VF4taaA==",
-      "peerDependencies": {
-        "@discordjs/opus": ">=0.8.0 <1.0.0",
-        "ffmpeg-static": "^5.0.2 || ^4.2.7 || ^3.0.0 || ^2.4.0",
-        "node-opus": "^0.3.3",
-        "opusscript": "^0.0.8"
-      },
-      "peerDependenciesMeta": {
-        "@discordjs/opus": {
-          "optional": true
-        },
-        "ffmpeg-static": {
-          "optional": true
-        },
-        "node-opus": {
-          "optional": true
-        },
-        "opusscript": {
-          "optional": true
-        }
       }
     },
     "node_modules/process-nextick-args": {
@@ -2634,21 +2526,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/readable-web-to-node-stream": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
-      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
-      "dependencies": {
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/require-from-string": {
@@ -2811,14 +2688,6 @@
         "speedtest-net": "bin/index.js"
       }
     },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
@@ -2884,22 +2753,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/strtok3": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.0.0.tgz",
-      "integrity": "sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/supports-color": {
@@ -2991,22 +2844,6 @@
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
       "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
     },
-    "node_modules/token-types": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz",
-      "integrity": "sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "ieee754": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/tough-cookie": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
@@ -3092,9 +2929,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.27.0.tgz",
-      "integrity": "sha512-l3ydWhlhOJzMVOYkymLykcRRXqbUaQriERtR70B9LzNkZ4bX52Fc8wbTDneMiwo8T+AemZXvXaTx+9o5ROxrXg==",
+      "version": "5.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.27.2.tgz",
+      "integrity": "sha512-iS857PdOEy/y3wlM3yRp+6SNQQ6xU0mmZcwRSriqk+et/cwWAtwmIGf6WkoDN2EK/AMdCO/dfXzIwi+rFMrjjQ==",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
@@ -3220,9 +3057,9 @@
       }
     },
     "node_modules/yahoo-finance2": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yahoo-finance2/-/yahoo-finance2-2.8.1.tgz",
-      "integrity": "sha512-1125oJYLQ5Bz9ne5jU1eACdE15cBFWMzYm04fY201eiqiWMK+s6YCJVuUyJVgWgXVt61wwr88/QageNCl0w04A==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yahoo-finance2/-/yahoo-finance2-2.9.0.tgz",
+      "integrity": "sha512-Q1UhB5uA0Uj2bBcSDqsZLt0tCxoHwrWCuvu4NMUgioyN8dlpq8ppbdKhZlzTD9ipIyKSgqG5TT7IlwB1x6eHZA==",
       "dependencies": {
         "@types/tough-cookie": "^4.0.2",
         "ajv": "8.10.0",

--- a/src/package.json
+++ b/src/package.json
@@ -1,20 +1,21 @@
 {
   "name": "morgana",
-  "version": "1.0.0",
+  "version": "3.0.0",
   "description": "",
   "main": "morgana.js",
   "dependencies": {
-    "@discordjs/opus": "^0.8.0",
-    "@discordjs/rest": "^1.0.1",
-    "@discordjs/voice": "^0.11.0",
-    "discord.js": "^14.2.0",
-    "dotenv": "^16.0.1",
-    "ffmpeg-static": "^5.0.2",
-    "libsodium-wrappers": "^0.7.10",
-    "openai": "^4.0.0",
-    "opusscript": "^0.0.8",
+    "@discordjs/opus": "^0.9.0",
+    "@discordjs/rest": "^2.2.0",
+    "@discordjs/voice": "^0.16.1",
+    "@mapbox/node-pre-gyp": "^1.0.11",
+    "discord.js": "^14.14.1",
+    "dotenv": "^16.3.1",
+    "ffmpeg-static": "^5.2.0",
+    "libsodium-wrappers": "^0.7.13",
+    "openai": "^4.20.1",
+    "opusscript": "^0.1.1",
     "speedtest-net": "^2.2.0",
-    "yahoo-finance2": "^2.4.1"
+    "yahoo-finance2": "^2.9.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Bump container version to Node 17 and bumped a bunch of other packages.

Upped Morgana's chat memory to 30 messages instead of 15.

For future releases, will bump to Node 18, and will deprecate speedtest command